### PR TITLE
update URL to thumbnails

### DIFF
--- a/apiqtpl.py
+++ b/apiqtpl.py
@@ -231,7 +231,7 @@ class API_PlanetLabs(QtCore.QObject):
   validKey = None
   urlRoot = "https://api.planet.com"
   urlQuickSearch = "https://api.planet.com/data/v1/quick-search"
-  urlThumbnail = "https://api.planet.com/data/v1/item-types/{item_type}/items/{item_id}/thumb"
+  urlThumbnail = "https://tiles.planet.com/data/v1/item-types/{item_type}/items/{item_id}/thumb"
   urlTMS = "https://tiles.planet.com/data/v1/{item_type}/{item_id}/{{z}}/{{x}}/{{y}}.png"
   urlAssets = "https://api.planet.com/data/v1/item-types/{item_type}/items/{item_id}/assets" 
 


### PR DESCRIPTION
Planet's Data API recently changed the endpoint for Thumbnail URLs - this update should allow the plugin to fetch thumbsnails again